### PR TITLE
Update ExcludeFileByNameFilterIterator.php

### DIFF
--- a/lib/private/IntegrityCheck/Iterator/ExcludeFileByNameFilterIterator.php
+++ b/lib/private/IntegrityCheck/Iterator/ExcludeFileByNameFilterIterator.php
@@ -39,6 +39,7 @@ class ExcludeFileByNameFilterIterator extends \RecursiveFilterIterator {
 		'.DS_Store', // Mac OS X
 		'Thumbs.db', // Microsoft Windows
 		'.directory', // Dolphin (KDE)
+		'.webapp', // Gentoo/Funtoo & derivatives use a tool known as webapp-config to manager wep-apps.
 	];
 
 	/**


### PR DESCRIPTION
Gentoo & derivatives use a tool named webapp-config which places two files in a webapp-config manager web application:
1: .webapp    tag with more detailed info on the configuration done by webapp-config
2: .webapp-appname   with the list of files installed by the tool to be able to later only delete stuff that was installed (in case of upgrade) and updated configurations.

Appearantly the .webapp-appname variant already is taken care of, just .webapp isn't yet.